### PR TITLE
Fix door reopening logic

### DIFF
--- a/game/world.py
+++ b/game/world.py
@@ -66,10 +66,16 @@ class Door:
                 if self.timer >= DOOR_CLOSE_DELAY:
                     self.state = "closing"
         elif self.state == "closing":
-            self.progress = max(0.0, self.progress - dt / DOOR_ANIM_DURATION)
-            if self.progress <= 0.0:
-                self.state = "closed"
-                self.timer = 0.0
+            if dist2 <= DOOR_OPEN_DISTANCE * DOOR_OPEN_DISTANCE:
+                # Reopen if player comes back while door is closing
+                self.state = "opening"
+            else:
+                self.progress = max(
+                    0.0, self.progress - dt / DOOR_ANIM_DURATION
+                )
+                if self.progress <= 0.0:
+                    self.state = "closed"
+                    self.timer = 0.0
 
 
 class World:


### PR DESCRIPTION
## Summary
- allow doors that are closing to reopen when the player gets close again

## Testing
- `black . -l 80`
- `pytest -q --disable-warnings --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_6847f9f22cb08331ac23ac5150a67530