### PR TITLE
Fix GL state after render

### DIFF
--- a/game/renderer.py
+++ b/game/renderer.py
@@ -757,6 +757,7 @@ void main() {
         gl.glPopMatrix()
         gl.glMatrixMode(gl.GL_PROJECTION)
         gl.glPopMatrix()
+        gl.glMatrixMode(gl.GL_MODELVIEW)
         # Swap buffers
         pygame.display.flip()
 


### PR DESCRIPTION
## Summary
- keep `GL_MODELVIEW` active when leaving `Renderer.render`

## Testing
- `pytest -q --disable-warnings --maxfail=1` *(fails: ModuleNotFoundError: No module named 'OpenGL')*
- `black . -l 80`

------
https://chatgpt.com/codex/tasks/task_e_6847fd30ecb08331a7c2c4637da32a88