### PR TITLE
Add room id test for door state

### DIFF
--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -186,3 +186,16 @@ def test_world_door_animation_progress_and_closing():
     w.update_doors(p, dt=DOOR_ANIM_DURATION)
     assert door.state == "closed"
     assert door.progress == 0.0
+
+
+def test_get_room_id_for_open_and_closed_door():
+    grid = [[0, 2, 0]]
+    w = World(map_grid=grid)
+    door = w.doors[0]
+    # Door closed should not return a room ID for its cell
+    assert w.get_room_id(1.5, 0.5) is None
+
+    door.state = "open"
+    door.progress = 1.0
+    expected = w.room_map[0][2]
+    assert w.get_room_id(1.5, 0.5) == expected


### PR DESCRIPTION
## Summary
- test `get_room_id` behaviour for doors when closed vs open

## Testing
- `pytest -q`
- `black . -l 80`


------
https://chatgpt.com/codex/tasks/task_e_6847fffd0b90833187fa16d76c6fecdd